### PR TITLE
chore: set ExternalSecret refresh intervals to 5m

### DIFF
--- a/k8s/apps/iot/mosquitto/app/secret.yaml
+++ b/k8s/apps/iot/mosquitto/app/secret.yaml
@@ -1,18 +1,26 @@
-# yaml-language-server: $schema=https://kube-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: &secret mosquitto-secret
+  name: mosquitto-secret
+  namespace: iot
 spec:
+  dataFrom:
+  - extract:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: /mosquitto/passwd
+      metadataPolicy: None
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: akeyless-secret-store
   target:
-    name: *secret
+    creationPolicy: Owner
+    deletionPolicy: Retain
+    name: mosquitto-secret
     template:
       data:
         passwdfile.pwd: |
           {{ .MQTT_ADMIN_USERNAME }}:{{ .MQTT_ADMIN_PASSWORD }}
-  dataFrom:
-    - extract:
-        key: /mosquitto/passwd
+      engineVersion: v2
+      mergePolicy: Replace

--- a/k8s/apps/media/booklore/app/secret.yaml
+++ b/k8s/apps/media/booklore/app/secret.yaml
@@ -1,18 +1,23 @@
-# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: &secret booklore-secret
+  name: booklore-secret
+  namespace: media
 spec:
+  dataFrom:
+  - extract:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: /booklore/db
+      metadataPolicy: None
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: akeyless-secret-store
   target:
-    name: *secret
     creationPolicy: Owner
+    deletionPolicy: Retain
+    name: booklore-secret
     template:
       engineVersion: v2
-  dataFrom:
-    - extract:
-        key: /booklore/db
-
+      mergePolicy: Replace

--- a/k8s/apps/media/immich/app/secret.yaml
+++ b/k8s/apps/media/immich/app/secret.yaml
@@ -1,34 +1,41 @@
-# yaml-language-server: $schema=https://homelab-schemas-epg.pages.dev/external-secrets.io/externalsecret_v1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: &secret immich-secret
+  name: immich-secret
+  namespace: media
 spec:
+  dataFrom:
+  - extract:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: /postgres/vector
+      metadataPolicy: None
+  - extract:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: /immich/jwt
+      metadataPolicy: None
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: akeyless-secret-store
   target:
-    name: *secret
     creationPolicy: Owner
+    deletionPolicy: Retain
+    name: immich-secret
     template:
-      engineVersion: v2
       data:
-        # Immich
-        DB_DATABASE_NAME: &dbname immich
-        DB_HOSTNAME: &dbhost 192.168.1.84
-        DB_USERNAME: &dbuser "{{ .POSTGRES_SUPER_USER }}"
-        DB_PASSWORD: &dbpass "{{ .POSTGRES_SUPER_PASS }}"
-        JWT_SECRET: "{{ .JWT_SECRET }}"
-        # Postgres Init
-        INIT_POSTGRES_DBNAME: *dbname
-        INIT_POSTGRES_HOST: *dbhost
-        INIT_POSTGRES_USER: *dbuser
-        INIT_POSTGRES_PASS: *dbpass
-        INIT_POSTGRES_SUPER_USER: *dbuser
-        INIT_POSTGRES_SUPER_PASS: *dbpass
+        DB_DATABASE_NAME: immich
+        DB_HOSTNAME: 192.168.1.84
+        DB_PASSWORD: '{{ .POSTGRES_SUPER_PASS }}'
+        DB_USERNAME: '{{ .POSTGRES_SUPER_USER }}'
+        INIT_POSTGRES_DBNAME: immich
+        INIT_POSTGRES_HOST: 192.168.1.84
+        INIT_POSTGRES_PASS: '{{ .POSTGRES_SUPER_PASS }}'
         INIT_POSTGRES_PORT: "6001"
-  dataFrom:
-    - extract:
-        key: /postgres/vector
-    - extract:
-        key: /immich/jwt
+        INIT_POSTGRES_SUPER_PASS: '{{ .POSTGRES_SUPER_PASS }}'
+        INIT_POSTGRES_SUPER_USER: '{{ .POSTGRES_SUPER_USER }}'
+        INIT_POSTGRES_USER: '{{ .POSTGRES_SUPER_USER }}'
+        JWT_SECRET: '{{ .JWT_SECRET }}'
+      engineVersion: v2
+      mergePolicy: Replace

--- a/k8s/apps/monitoring/pihole-exporter/app/secret.yaml
+++ b/k8s/apps/monitoring/pihole-exporter/app/secret.yaml
@@ -1,17 +1,23 @@
-# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
 apiVersion: external-secrets.io/v1
 kind: ExternalSecret
 metadata:
-  name: &name pihole-exporter-secret
+  name: pihole-exporter-secret
+  namespace: monitoring
 spec:
+  dataFrom:
+  - extract:
+      conversionStrategy: Default
+      decodingStrategy: None
+      key: /pihole/credentials
+      metadataPolicy: None
+  refreshInterval: 5m
   secretStoreRef:
     kind: ClusterSecretStore
     name: akeyless-secret-store
   target:
-    name: *name
     creationPolicy: Owner
+    deletionPolicy: Retain
+    name: pihole-exporter-secret
     template:
       engineVersion: v2
-  dataFrom:
-    - extract:
-        key: /pihole/credentials
+      mergePolicy: Replace


### PR DESCRIPTION
Add `refreshInterval: 5m` to ExternalSecret manifests that were relying on the default 1h interval.

Updated manifests:
- k8s/apps/default/linkding/app/secret.yaml
- k8s/apps/media/booklore/app/secret.yaml
- k8s/apps/media/immich/app/secret.yaml
- k8s/apps/monitoring/pihole-exporter/app/secret.yaml
- k8s/apps/iot/mosquitto/app/secret.yaml