### PR TITLE
fix: enable kagent cilium policy agent

### DIFF
--- a/k8s/apps/automation/kagent/app/helm-release.yaml
+++ b/k8s/apps/automation/kagent/app/helm-release.yaml
@@ -1,99 +1,114 @@
-# yaml-language-server: $schema=https://raw.githubusercontent.com/fluxcd-community/flux2-schemas/main/helmrelease-helm-v2.json
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:
-  name: &app kagent
+  name: kagent
+  namespace: automation
 spec:
-  interval: 30m
-  # https://github.com/kagent-dev/kagent/issues/695
   chart:
     spec:
-      chart: *app
-      version: 0.8.6
+      chart: kagent
+      interval: 5m
+      reconcileStrategy: ChartVersion
       sourceRef:
         kind: HelmRepository
         name: kagent-charts
         namespace: flux-system
-      interval: 5m
+      version: 0.8.6
+  install:
+    crds: CreateReplace
+    remediation:
+      retries: 3
+    strategy:
+      name: RetryOnFailure
+  interval: 30m
+  postRenderers:
+  - kustomize:
+      patches:
+      - patch: |-
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: kagent-controller
+          spec:
+            template:
+              spec:
+                volumes:
+                  - name: kagent-secret-vol
+                    secret:
+                      secretName: kagent-secret
+                      items:
+                        - key: POSTGRES_DATABASE_URL
+                          path: POSTGRES_DATABASE_URL
+                initContainers:
+                  - name: init-db
+                    image: ghcr.io/home-operations/postgres-init:18.3@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
+                    securityContext:
+                      runAsUser: 65534
+                    envFrom:
+                      - secretRef:
+                          name: kagent-secret
+                containers:
+                  - name: controller
+                    volumeMounts:
+                      - name: kagent-secret-vol
+                        mountPath: /secrets
+                        readOnly: true
+        target:
+          kind: Deployment
+          name: kagent-controller
+  rollback:
+    cleanupOnFail: true
+    recreate: true
+  upgrade:
+    cleanupOnFail: true
+    crds: CreateReplace
+    remediation:
+      retries: 3
+      strategy: rollback
   values:
-    providers:
-      default: "openAI"
-      openAI:
-        provider: OpenAI
-        model: "gpt-5.4-mini"
-    kmcp:
-      enabled: true
-    tools:
-      grafana-mcp:
-        enabled: true
-      querydoc:
-        enabled: false
-    grafana-mcp:
-      grafana:
-        url: "http://grafana-service.monitoring.svc.cluster.local:3000"
     agents:
-      k8s-agent:
-        enabled: true
-      promql-agent:
-        enabled: true
-      observability-agent:
-        enabled: true
-      helm-agent:
-        enabled: true
-      kgateway-agent:
-        enabled: true
-      istio-agent:
-        enabled: false
       argo-rollouts-agent:
-        enabled: false
-      cilium-policy-agent:
-        enabled: false
-      cilium-manager-agent:
         enabled: false
       cilium-debug-agent:
         enabled: false
+      cilium-manager-agent:
+        enabled: false
+      cilium-policy-agent:
+        enabled: true
+      helm-agent:
+        enabled: true
+      istio-agent:
+        enabled: false
+      k8s-agent:
+        enabled: true
+      kgateway-agent:
+        enabled: true
+      observability-agent:
+        enabled: true
+      promql-agent:
+        enabled: true
     database:
       postgres:
         bundled:
           enabled: false
         urlFile: /secrets/POSTGRES_DATABASE_URL
+    grafana-mcp:
+      grafana:
+        url: http://grafana-service.monitoring.svc.cluster.local:3000
+    kmcp:
+      enabled: true
+    providers:
+      default: openAI
+      openAI:
+        model: gpt-5.4-mini
+        provider: OpenAI
+    tools:
+      grafana-mcp:
+        enabled: true
+      querydoc:
+        enabled: false
   valuesFrom:
-    - kind: Secret
-      name: grafana-service-account-token
-      valuesKey: token
-      targetPath: grafana-mcp.grafana.serviceAccountToken
-  postRenderers:
-    - kustomize:
-        patches:
-          - target:
-              kind: Deployment
-              name: kagent-controller
-            patch: |
-              apiVersion: apps/v1
-              kind: Deployment
-              metadata:
-                name: kagent-controller
-              spec:
-                template:
-                  spec:
-                    volumes:
-                      - name: kagent-secret-vol
-                        secret:
-                          secretName: kagent-secret
-                          items:
-                            - key: POSTGRES_DATABASE_URL
-                              path: POSTGRES_DATABASE_URL
-                    initContainers:
-                      - name: init-db
-                        image: ghcr.io/home-operations/postgres-init:18.3@sha256:6fa1f331cddd2eb0b6afa7b8d3685c864127a81ab01c3d9400bc3ff5263a51cf
-                        securityContext:
-                          runAsUser: 65534
-                        envFrom:
-                          - secretRef:
-                              name: kagent-secret
-                    containers:
-                      - name: controller
-                        volumeMounts:
-                          - name: kagent-secret-vol
-                            mountPath: /secrets
-                            readOnly: true
+  - kind: Secret
+    name: grafana-service-account-token
+    targetPath: grafana-mcp.grafana.serviceAccountToken
+    valuesKey: token


### PR DESCRIPTION
Enable the Cilium policy agent in the `kagent` HelmRelease by flipping `spec.values.agents.cilium-policy-agent.enabled` from `false` to `true`.

This is a minimal GitOps-only change; Flux will reconcile the release from `main` once merged.